### PR TITLE
Исправление отступов включных формул

### DIFF
--- a/preamble.tex
+++ b/preamble.tex
@@ -953,7 +953,12 @@
 \newlength{\eqindent}
 \setlength{\eqindent}{1.4em} % Recommended: baselineskip, 1.3em, 1.4em, 1.5em
 
-\AtBeginEnvironment{equation}{\setlength\abovedisplayskip{\eqindent - \baselineskip}}
-\AtBeginEnvironment{equation}{\setlength\belowdisplayskip{\eqindent}}
-\AtBeginEnvironment{equation}{\setlength\abovedisplayshortskip{\eqindent - \baselineskip}}
-\AtBeginEnvironment{equation}{\setlength\belowdisplayshortskip{\eqindent}}
+\usepackage{pgffor}
+
+% Note: if necessary, supplement the list with the necessary math environment
+\foreach \env in {equation, equation*, align, align*}{
+    \AtBeginEnvironment{\env}{\setlength\abovedisplayskip{\eqindent - \baselineskip}}
+    \AtBeginEnvironment{\env}{\setlength\belowdisplayskip{\eqindent}}
+    \AtBeginEnvironment{\env}{\setlength\abovedisplayshortskip{\eqindent - \baselineskip}}
+    \AtBeginEnvironment{\env}{\setlength\belowdisplayshortskip{\eqindent}}
+}

--- a/preamble.tex
+++ b/preamble.tex
@@ -948,3 +948,12 @@
 % Зачем: добавляем пользовательские константы конфигурации
 % Всегда располагаем в конце для использования всех плагинов
 \input{\commonCfgPathPrefix cfg}
+
+% Зачем: правильные отступы включных формул в тексте
+\newlength{\eqindent}
+\setlength{\eqindent}{1.4em} % Recommended: baselineskip, 1.3em, 1.4em, 1.5em
+
+\AtBeginEnvironment{equation}{\setlength\abovedisplayskip{\eqindent - \baselineskip}}
+\AtBeginEnvironment{equation}{\setlength\belowdisplayskip{\eqindent}}
+\AtBeginEnvironment{equation}{\setlength\abovedisplayshortskip{\eqindent - \baselineskip}}
+\AtBeginEnvironment{equation}{\setlength\belowdisplayshortskip{\eqindent}}


### PR DESCRIPTION
Некоторая предыстория [тут](https://github.com/Qurcaivel/bsuir-latex/issues/10) и [тут](https://github.com/fcsan-bsuir/bsuir_tex/pull/7).
Решение лежало на поверхности. Как и я. Последние полтора года. Извините.

NOTE: Фикс добавлен по принципу беглого патча. Значение длины \eqindent должно быть уточнено, а исправление протестировано на тексте с множеством включных формул различной высоты.

PS1. Хотел приложить текст для теста, но уже отправил сообщение.
PS2. Да прибудет с вами lipsum и showframe.